### PR TITLE
feat(rules): add more CEL rules for protocol is -1

### DIFF
--- a/apis/definition.yaml
+++ b/apis/definition.yaml
@@ -53,6 +53,8 @@ spec:
                             message: "When fromPort and toPort are specified, either cidrBlocks or sourceSecurityGroupName must be set."
                           - rule: "!has(self.isSelf) || (self.isSelf == false || (!has(self.cidrBlocks) && !has(self.sourceSecurityGroupName)))"
                             message: "When isSelf is true, neither cidrBlocks nor sourceSecurityGroupName can be specified."
+                          - rule: "!(self.protocol == '-1' && (has(self.fromPort) || has(self.toPort)))"
+                            message: "When protocol is -1, toPort and fromPort cannot be set."
                         properties:
                           type:
                             type: string


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes
its not allowed to specify toPort and fromPort when protocol is -1

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Fixes #

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
